### PR TITLE
Add PPO agent and support pure online training

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,7 +1,9 @@
 from agents.acfql import ACFQLAgent
 from agents.acrlpd import ACRLPDAgent
+from agents.ppo import PPOAgent
 
 agents = dict(
     acfql=ACFQLAgent,
     acrlpd=ACRLPDAgent,
+    ppo=PPOAgent,
 )

--- a/agents/ppo.py
+++ b/agents/ppo.py
@@ -78,14 +78,14 @@ class PPOAgent(flax.struct.PyTreeNode):
         return self.replace(network=new_network, rng=new_rng), info
 
     @partial(jax.jit, static_argnames=('return_log_prob',))
-    def sample_actions(self, observations, seed=None, temperature=1.0, return_log_prob=False):
+    def sample_actions(self, observations, rng=None, temperature=1.0, return_log_prob=False):
         dist = self.network.select('actor')(observations, temperature=temperature)
         if return_log_prob:
-            actions, log_prob = dist.sample_and_log_prob(seed=seed)
+            actions, log_prob = dist.sample_and_log_prob(seed=rng)
             actions = jnp.clip(actions, -1, 1)
             return actions, log_prob
         else:
-            actions = dist.sample(seed=seed)
+            actions = dist.sample(seed=rng)
             actions = jnp.clip(actions, -1, 1)
             return actions
 


### PR DESCRIPTION
## Summary
- register PPOAgent and refine action sampling interface
- allow main_online to run without offline datasets and handle PPO training with log-prob storage
- update training loop to sample on-policy data and perform PPO updates

## Testing
- `python -m py_compile agents/ppo.py agents/__init__.py main_online.py`
- `python - <<'PY'
import numpy as np
from agents.ppo import PPOAgent, get_config
cfg = get_config()
obs = np.zeros((4,), dtype=np.float32)
act = np.zeros((2,), dtype=np.float32)
agent = PPOAgent.create(seed=0, ex_observations=obs, ex_actions=act, config=cfg)
batch = {
    'observations': np.zeros((16,4), dtype=np.float32),
    'actions': np.zeros((16,2), dtype=np.float32),
    'rewards': np.zeros((16,), dtype=np.float32),
    'masks': np.ones((16,), dtype=np.float32),
    'terminals': np.zeros((16,), dtype=np.float32),
    'next_observations': np.zeros((16,4), dtype=np.float32),
    'log_probs': np.zeros((16,), dtype=np.float32),
}
agent, info = agent.update(batch)
print('update done', info['actor_loss'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b7f456bc748329a39c219423bb7054